### PR TITLE
Open new files in a pending state in goToLocation

### DIFF
--- a/modules/nuclide-commons-atom/go-to-location.js
+++ b/modules/nuclide-commons-atom/go-to-location.js
@@ -65,6 +65,7 @@ export async function goToLocation(
       initialLine: line,
       initialColumn: column,
       searchAllPanes: true,
+      pending: true,
     });
 
     if (center && line != null) {


### PR DESCRIPTION
Tracked the source of this behaviour down when using ctrl-click in Atom IDE. I feel that pending tabs are the right UX when I'm navigating around a codebase. Remember that pending tabs can be turned off globally in Atom if a user dislikes them.

---

Unsure the proper way to contribute here so I submitted this and https://github.com/facebook/nuclide/pull/1306