### PR TITLE
Fixed Datatip service name

### DIFF
--- a/docs/datatips.md
+++ b/docs/datatips.md
@@ -20,7 +20,7 @@ Consume the datatip [Atom service](http://flight-manual.atom.io/behind-atom/sect
 "consumedServices": {
   "datatip": {
     "versions": {
-      "0.1.0": "consumeDatatipService"
+      "0.1.0": "consumeDatatip"
     }
   }
 }

--- a/docs/datatips.md
+++ b/docs/datatips.md
@@ -29,7 +29,7 @@ Consume the datatip [Atom service](http://flight-manual.atom.io/behind-atom/sect
 Then, in your package entry point, add:
 
 ```
-export function consumeDatatipService(datatipService) {}
+export function consumeDatatip(datatipService) {}
 ```
 
 `datatipService` will be a `DatatipService` object


### PR DESCRIPTION
I noticed, that the documented way doesn't work and then saw that other packages use it differently. See for example

https://github.com/atom/ide-typescript/blob/293c14818bd3c6a68c08978ae8e5e1f37d46767f/package.json#L46-L50