### PR TITLE
Fix dragging pinned datatips with 'above-range' position

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-datatip/lib/PinnedDatatip.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-datatip/lib/PinnedDatatip.js
@@ -219,7 +219,7 @@ export class PinnedDatatip {
       case 'above-range':
         _hostElement.style.bottom =
           _editor.getLineHeightInPixels() +
-          _hostElement.clientHeight +
+          _hostElement.clientHeight -
           _offset.y +
           'px';
         _hostElement.style.left = _offset.x + 'px';


### PR DESCRIPTION
This fixes an issue where dragging a pinned datatip up or down moves it in the opposite direction.

**Gif showing the issue**:
![issue](https://user-images.githubusercontent.com/10126466/33225048-f1aa200e-d170-11e7-969a-8d3254fd5c06.gif)