### PR TITLE
Move Nuclide warning before the transpiler hook

### DIFF
--- a/display-nuclide-warning.js
+++ b/display-nuclide-warning.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @noflow
+ */
+'use strict';
+
+/* eslint
+  comma-dangle: [1, always-multiline],
+  prefer-object-spread/prefer-object-spread: 0,
+  rulesdir/no-commonjs: 0,
+  */
+
+const HIDE_WARNING_KEY = 'atom-ide-ui.hideNuclideWarning';
+
+module.exports = function displayNuclideWarning() {
+  if (!atom.config.get(HIDE_WARNING_KEY)) {
+    const notification = atom.notifications.addInfo(
+      'Atom IDE UI is bundled with Nuclide',
+      {
+        description:
+          '`atom-ide-ui` will be deactivated in favor of Nuclide.<br>' +
+          'Please disable Nuclide if you only want to use `atom-ide-ui`.',
+        dismissable: true,
+        buttons: [
+          {
+            text: 'Disable Nuclide and reload',
+            onDidClick() {
+              atom.packages.disablePackage('nuclide');
+              atom.reload();
+              notification.dismiss();
+            },
+          },
+          {
+            text: 'Disable atom-ide-ui',
+            onDidClick() {
+              atom.packages.disablePackage('atom-ide-ui');
+              notification.dismiss();
+            },
+          },
+          {
+            text: "Don't warn me again",
+            onDidClick() {
+              atom.config.set(HIDE_WARNING_KEY, true);
+              notification.dismiss();
+            },
+          },
+        ],
+      }
+    );
+  }
+};

--- a/index-entry.js
+++ b/index-entry.js
@@ -17,13 +17,24 @@
   */
 
 /**
- * Load the transpiler's require hook in development mode.
- * This also puts modules/ into the module resolution path.
+ * This check needs to happen before the transpiler hook is loaded -
+ * otherwise, this will conflict with Nuclide's transpiler hook :(
  */
+if (
+  !atom.packages.isPackageDisabled('nuclide') &&
+  atom.packages.getAvailablePackageNames().includes('nuclide')
+) {
+  const displayNuclideWarning = require('./display-nuclide-warning');
+  displayNuclideWarning();
+} else {
+  /**
+   * Load the transpiler's require hook in development mode.
+   * This also puts modules/ into the module resolution path.
+   */
+  const {__DEV__} = require('./modules/nuclide-node-transpiler/lib/env');
+  if (__DEV__) {
+    require('./modules/nuclide-node-transpiler');
+  }
 
-const {__DEV__} = require('./modules/nuclide-node-transpiler/lib/env');
-if (__DEV__) {
-  require('./modules/nuclide-node-transpiler');
+  module.exports = require('./index');
 }
-
-module.exports = require('./index');

--- a/index.js
+++ b/index.js
@@ -17,103 +17,64 @@ import fs from 'fs';
 import path from 'path';
 import UniversalDisposable from 'nuclide-commons/UniversalDisposable';
 import FeatureLoader from 'nuclide-commons-atom/FeatureLoader';
+import displayNuclideWarning from './display-nuclide-warning';
 
-const HIDE_WARNING_KEY = 'atom-ide-ui.hideNuclideWarning';
-
-function displayNuclideWarning() {
-  if (!atom.config.get(HIDE_WARNING_KEY)) {
-    const notification = atom.notifications.addInfo(
-      'Atom IDE UI is bundled with Nuclide',
-      {
-        description:
-          '`atom-ide-ui` will be deactivated in favor of Nuclide.<br>' +
-          'Please disable Nuclide if you only want to use `atom-ide-ui`.',
-        dismissable: true,
-        buttons: [
-          {
-            text: 'Disable Nuclide and reload',
-            onDidClick() {
-              atom.packages.disablePackage('nuclide');
-              atom.reload();
-              notification.dismiss();
-            },
-          },
-          {
-            text: "Don't warn me again",
-            onDidClick() {
-              atom.config.set(HIDE_WARNING_KEY, true);
-              notification.dismiss();
-            },
-          },
-        ],
-      },
-    );
-  }
-}
-
-if (
-  !atom.packages.isPackageDisabled('nuclide') &&
-  atom.packages.getAvailablePackageNames().includes('nuclide')
-) {
-  displayNuclideWarning();
-} else {
-  const featureDir = path.join(__dirname, 'modules/atom-ide-ui/pkg');
-  const features = fs
-    .readdirSync(featureDir)
-    .map(item => {
-      const dirname = path.join(featureDir, item);
-      try {
-        const pkgJson = fs.readFileSync(
-          path.join(dirname, 'package.json'),
-          'utf8',
-        );
-        return {
-          dirname,
-          pkg: JSON.parse(pkgJson),
-        };
-      } catch (err) {
-        if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
-          throw err;
-        }
-      }
-    })
-    .filter(Boolean);
-
-  /**
-   * Use a unified package loader to load all the feature packages.
-   * See the following post for more context:
-   * https://nuclide.io/blog/2016/01/13/Nuclide-v0.111.0-The-Unified-Package/
-   */
-  let disposables: ?UniversalDisposable;
-  const featureLoader = new FeatureLoader({
-    pkgName: 'atom-ide-ui',
-    config: {},
-    features,
-  });
-  featureLoader.load();
-
-  module.exports = {
-    config: featureLoader.getConfig(),
-    activate() {
-      disposables = new UniversalDisposable(
-        require('nuclide-commons-ui'),
-        atom.packages.onDidActivatePackage(pkg => {
-          if (pkg.name === 'nuclide') {
-            displayNuclideWarning();
-          }
-        }),
+const featureDir = path.join(__dirname, 'modules/atom-ide-ui/pkg');
+const features = fs
+  .readdirSync(featureDir)
+  .map(item => {
+    const dirname = path.join(featureDir, item);
+    try {
+      const pkgJson = fs.readFileSync(
+        path.join(dirname, 'package.json'),
+        'utf8',
       );
-      featureLoader.activate();
-    },
-    deactivate() {
-      featureLoader.deactivate();
-      if (disposables != null) {
-        disposables.dispose();
-        disposables = null;
+      return {
+        dirname,
+        pkg: JSON.parse(pkgJson),
+      };
+    } catch (err) {
+      if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
+        throw err;
       }
-    },
-    serialize() {
-      featureLoader.serialize();
-    },
-  };
-}
+    }
+  })
+  .filter(Boolean);
+
+/**
+ * Use a unified package loader to load all the feature packages.
+ * See the following post for more context:
+ * https://nuclide.io/blog/2016/01/13/Nuclide-v0.111.0-The-Unified-Package/
+ */
+let disposables: ?UniversalDisposable;
+const featureLoader = new FeatureLoader({
+  pkgName: 'atom-ide-ui',
+  config: {},
+  features,
+});
+featureLoader.load();
+
+module.exports = {
+  config: featureLoader.getConfig(),
+  activate() {
+    disposables = new UniversalDisposable(
+      require('nuclide-commons-ui'),
+      atom.packages.onDidActivatePackage(pkg => {
+        if (pkg.name === 'nuclide') {
+          displayNuclideWarning();
+        }
+      }),
+    );
+    featureLoader.activate();
+  },
+  deactivate() {
+    featureLoader.deactivate();
+    if (disposables != null) {
+      disposables.dispose();
+      disposables = null;
+    }
+  },
+  serialize() {
+    featureLoader.serialize();
+  },
+};


### PR DESCRIPTION
1) Nuclide detection needs to happen before the transpiler hook is loaded so that we avoid conflicting with Nuclide's transpiler hook (and module path modification).
2) Add an additional option to just disable `atom-ide-ui` altogether if Nuclide is installed. (There's still the 'ignore' option, at the request of some Atom team members who frequently switch between the two.)

/cc @bolinfest 