### PR TITLE
Refocus after application of Code Action

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsCodeActions.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsCodeActions.js
@@ -35,7 +35,18 @@ export default function DiagnosticsCodeActions(props: {
                 size="EXTRA_SMALL"
                 onClick={() => {
                   // TODO: (seansegal) T21130332 Display CodeAction status indicators
-                  codeAction.apply().catch(handleCodeActionFailure);
+                  codeAction
+                    .apply()
+                    .then(() => {
+                      const activeItem = atom.workspace.getActivePaneItem();
+                      if (
+                        activeItem &&
+                        activeItem.element instanceof window.HTMLElement
+                      ) {
+                        activeItem.element.focus();
+                      }
+                    })
+                    .catch(handleCodeActionFailure);
                 }}>
                 <span className="inline-block">{title}</span>
               </Button>

--- a/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsCodeActions.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsCodeActions.js
@@ -37,6 +37,7 @@ export default function DiagnosticsCodeActions(props: {
                   // TODO: (seansegal) T21130332 Display CodeAction status indicators
                   codeAction
                     .apply()
+                    .catch(handleCodeActionFailure)
                     .then(() => {
                       const activeItem = atom.workspace.getActivePaneItem();
                       if (
@@ -45,8 +46,7 @@ export default function DiagnosticsCodeActions(props: {
                       ) {
                         activeItem.element.focus();
                       }
-                    })
-                    .catch(handleCodeActionFailure);
+                    });
                 }}>
                 <span className="inline-block">{title}</span>
               </Button>

--- a/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsCodeActions.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsCodeActions.js
@@ -12,6 +12,7 @@
 
 import type {CodeAction} from '../../../atom-ide-code-actions/lib/types';
 
+import {TextEditor} from 'atom';
 import * as React from 'react';
 import {Button} from 'nuclide-commons-ui/Button';
 import {ButtonGroup} from 'nuclide-commons-ui/ButtonGroup';
@@ -39,11 +40,9 @@ export default function DiagnosticsCodeActions(props: {
                     .apply()
                     .catch(handleCodeActionFailure)
                     .then(() => {
+                      // Return focus to the editor after clicking.
                       const activeItem = atom.workspace.getActivePaneItem();
-                      if (
-                        activeItem &&
-                        activeItem.element instanceof window.HTMLElement
-                      ) {
+                      if (activeItem && activeItem instanceof TextEditor) {
                         activeItem.element.focus();
                       }
                     });

--- a/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsPopup.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsPopup.js
@@ -76,6 +76,14 @@ function getCodeActions(
               },
               async apply() {
                 action.apply();
+
+                const activeItem = atom.workspace.getActivePaneItem();
+                if (
+                  activeItem &&
+                  activeItem.element instanceof window.HTMLElement
+                ) {
+                  activeItem.element.focus();
+                }
               },
               dispose() {},
             },

--- a/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsPopup.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsPopup.js
@@ -76,14 +76,6 @@ function getCodeActions(
               },
               async apply() {
                 action.apply();
-
-                const activeItem = atom.workspace.getActivePaneItem();
-                if (
-                  activeItem &&
-                  activeItem.element instanceof window.HTMLElement
-                ) {
-                  activeItem.element.focus();
-                }
               },
               dispose() {},
             },


### PR DESCRIPTION
After the application of a code action return focus to active text editor to prevent the appearance of 'cursor locking' after applying a code action. I made this change in two places, for my test actions I only observed the code in `DiagnosticsCodeActions.js` actually being ran. My assumption being that the two calls to the underlying code action's `apply` method are mutually exclusive, feel free to correct me if that's a bad assumption. Also note that in `DiagnosticsCodeActions.js` the 'active element' is refocused even after code action failure, this seems like the desired behavior but let me know if it's not for any reason.

Fixes #147 