### PR TITLE
Support url fragments & queries in diagnostic message text

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsMessageText.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/lib/ui/DiagnosticsMessageText.js
@@ -37,7 +37,15 @@ export function separateUrls(message: string): Array<UrlOrText> {
   // Don't match periods at the end of URLs, because those are usually just to
   // end the sentence and not actually part of the URL. Optionally match
   // parameters following a question mark.
-  const urlRegex = /https?:\/\/[\w/._%-]*[\w/_-](?:\?[\w/_=&-]*)?/g;
+
+  // first bit before query/fragment
+  const mainUrl = /https?:\/\/[\w/.%-]*[\w/-]/.source;
+  // characters allowed in query/fragment, disallow `.` at the end
+  const queryChars = /[\w-~%&+.!=:@/?]*[\w-~%&+!=:@/?]/.source;
+  const urlRegex = new RegExp(
+    `${mainUrl}(?:\\?${queryChars})?(?:#${queryChars})?`,
+    'g',
+  );
 
   const urls = message.match(urlRegex);
   const nonUrls = message.split(urlRegex);

--- a/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/spec/DiagnosticMessageTest-spec.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-diagnostics-ui/spec/DiagnosticMessageTest-spec.js
@@ -72,4 +72,31 @@ describe('DiagnosticsMessageText', () => {
       {isUrl: false, text: ''},
     ]);
   });
+
+  it('should handle URLs that include a query', () => {
+    expect(
+      separateUrls(
+        'help: https://example.com/foo.html?q=%20+!&-._~:@/?-hmm. (weird url huh?)',
+      ),
+    ).toEqual([
+      {isUrl: false, text: 'help: '},
+      {isUrl: true, url: 'https://example.com/foo.html?q=%20+!&-._~:@/?-hmm'},
+      {isUrl: false, text: '. (weird url huh?)'},
+    ]);
+  });
+
+  it('should handle URLs that include a fragment', () => {
+    expect(
+      separateUrls(
+        'help: https://example.com/foo.html#frag%20+!&=-._~:@/?-name. (weird url huh?)',
+      ),
+    ).toEqual([
+      {isUrl: false, text: 'help: '},
+      {
+        isUrl: true,
+        url: 'https://example.com/foo.html#frag%20+!&=-._~:@/?-name',
+      },
+      {isUrl: false, text: '. (weird url huh?)'},
+    ]);
+  });
 });


### PR DESCRIPTION
Currently diagnostic messages don't handled URLs with fragments. This pr adds support for fragments plus similar query support closer to [RFC 3986](https://tools.ietf.org/html/rfc3986#appendix-A) / atom editors own URL recognition.

### Before
![no-fragment](https://user-images.githubusercontent.com/2331607/35727457-112f4c68-0800-11e8-8d3c-09bd78df04be.png)

### After
![fragment](https://user-images.githubusercontent.com/2331607/35727468-1628efe4-0800-11e8-8346-aae337e88afd.png)

### Implementation notes
I broke the regex up into bits because otherwise it was:
```js
/https?:\/\/[\w/.%-]*[\w/-](?:\?[\w-~%&+.!=:@/?]*[\w-~%&+!=:@/?])?(?:#[\w-~%&+.!=:@/?]*[\w-~%&+!=:@/?])?/g
```
