### PR TITLE
import @syntax-background-color from syntax-variables

### DIFF
--- a/modules/nuclide-commons-ui/styles/LinePreview.less
+++ b/modules/nuclide-commons-ui/styles/LinePreview.less
@@ -1,4 +1,4 @@
-@import 'ui-variables';
+@import 'syntax-variables';
 
 atom-text-editor .line.nuclide-line-preview {
   // Similar to how one-dark-syntax computes its own (internal)


### PR DESCRIPTION
I don't believe `@syntax-background-color` is normally defined in `ui-variables`, so `atom-ide-ui` seems to throw errors like so:

![screen shot 2018-02-02 at 6 08 01 pm](https://user-images.githubusercontent.com/5678694/35758894-496e8064-0844-11e8-90a9-1554c2192f64.png)

Some themes like `one-dark` seem to be [importing those syntax variables](https://github.com/atom/one-dark-ui/blob/master/styles/ui-variables-custom.less#L5) which is why those themes seem to work fine.

This change should make sure that all themes work correctly. 