### PR TITLE
Restore support for icons passed directly.

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-outline-view/lib/OutlineView.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-outline-view/lib/OutlineView.js
@@ -14,13 +14,14 @@ import type {OutlineForUi, OutlineTreeForUi} from './createOutlines';
 import type {TextToken} from 'nuclide-commons/tokenized-text';
 import type {TreeNode, NodePath} from 'nuclide-commons-ui/SelectableTree';
 
-import Atomicon from 'nuclide-commons-ui/Atomicon';
+import Atomicon, {getTypeFromIconName} from 'nuclide-commons-ui/Atomicon';
 import HighlightedText from 'nuclide-commons-ui/HighlightedText';
 import {arrayEqual} from 'nuclide-commons/collection';
 import memoizeUntilChanged from 'nuclide-commons/memoizeUntilChanged';
 import UniversalDisposable from 'nuclide-commons/UniversalDisposable';
 
 import * as React from 'react';
+import classnames from 'classnames';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
 
@@ -412,9 +413,23 @@ function renderItem(
 ): React.Element<string> | string {
   const r = [];
 
-  if (outline.kind != null) {
+  const iconName = outline.icon;
+  if (iconName != null) {
+    const correspondingAtomicon = getTypeFromIconName(iconName);
+    if (correspondingAtomicon == null) {
+      r.push(
+        <span
+          key="type-icon"
+          className={classnames('icon', `icon-${iconName}`)}
+        />,
+      );
+    } else {
+      // If we're passed an icon name rather than a type, and it maps directly
+      // to an atomicon, use that.
+      r.push(<Atomicon key="type-icon" type={correspondingAtomicon} />);
+    }
+  } else if (outline.kind != null) {
     r.push(<Atomicon key="type-icon" type={outline.kind} />);
-    // Note: icons here are fixed-width, so the text lines up.
   }
 
   if (outline.tokenizedText != null) {

--- a/modules/nuclide-commons-ui/Atomicon.js
+++ b/modules/nuclide-commons-ui/Atomicon.js
@@ -38,9 +38,9 @@ const TYPE_TO_ICON_NAME = {
 
 const ICON_NAME_TO_TYPE = invert(TYPE_TO_ICON_NAME);
 
-type AtomiconName = $Keys<typeof TYPE_TO_ICON_NAME>;
+type AtomiconType = $Keys<typeof TYPE_TO_ICON_NAME>;
 
-export default function Atomicon({type}: {type: AtomiconName}) {
+export default function Atomicon({type}: {type: AtomiconType}) {
   const displayName = capitalize(type);
   return (
     <span
@@ -51,6 +51,6 @@ export default function Atomicon({type}: {type: AtomiconName}) {
   );
 }
 
-export function getTypeFromIconName(iconName: string): ?AtomiconName {
+export function getTypeFromIconName(iconName: string): ?AtomiconType {
   return ICON_NAME_TO_TYPE[iconName];
 }

--- a/modules/nuclide-commons-ui/Atomicon.js
+++ b/modules/nuclide-commons-ui/Atomicon.js
@@ -13,8 +13,9 @@
 import * as React from 'react';
 import {capitalize} from 'nuclide-commons/string';
 import classnames from 'classnames';
+import {invert} from 'lodash'
 
-const TYPE_TO_CLASSNAME_SUFFIX = {
+const TYPE_TO_ICON_NAME = {
   array: 'type-array',
   boolean: 'type-boolean',
   class: 'type-class',
@@ -35,16 +36,21 @@ const TYPE_TO_CLASSNAME_SUFFIX = {
   variable: 'type-variable',
 };
 
-type AtomiconName = $Keys<typeof TYPE_TO_CLASSNAME_SUFFIX>;
+const ICON_NAME_TO_TYPE = invert(TYPE_TO_ICON_NAME);
+
+type AtomiconName = $Keys<typeof TYPE_TO_ICON_NAME>;
 
 export default function Atomicon({type}: {type: AtomiconName}) {
   const displayName = capitalize(type);
   return (
     <span
-      aria-label={displayName}
-      className={classnames('icon', 'icon-' + TYPE_TO_CLASSNAME_SUFFIX[type])}
+      className={classnames('icon', 'icon-' + TYPE_TO_ICON_NAME[type])}
       role="presentation"
       title={displayName}
     />
   );
+}
+
+export function getTypeFromIconName(iconName: string): ?AtomiconName {
+  return ICON_NAME_TO_TYPE[iconName];
 }

--- a/modules/nuclide-commons-ui/Atomicon.js
+++ b/modules/nuclide-commons-ui/Atomicon.js
@@ -13,7 +13,7 @@
 import * as React from 'react';
 import {capitalize} from 'nuclide-commons/string';
 import classnames from 'classnames';
-import {invert} from 'lodash'
+import {invert} from 'lodash';
 
 const TYPE_TO_ICON_NAME = {
   array: 'type-array',

--- a/modules/nuclide-commons-ui/package.json
+++ b/modules/nuclide-commons-ui/package.json
@@ -18,6 +18,7 @@
     "escape-string-regexp": "1.0.5",
     "idx": "1.2.0",
     "invariant": "2.2.2",
+    "lodash": "4.17.4",
     "nuclide-commons": "0.5.1",
     "nuclide-commons-atom": "0.5.0",
     "nullthrows": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "idx": "1.2.0",
     "immutable": "4.0.0-rc.9",
     "invariant": "2.2.2",
+    "lodash": "4.17.4",
     "log4js": "1.1.1",
     "lru-cache": "4.0.2",
     "marked": "0.3.9",


### PR DESCRIPTION
Resolves #175.

This was inadvertantly removed when adding support for titles for
outline nodes that gave a `kind`.

In the case the passed icon is itself an Atomicon, we look up the
corresponding name of the Atomicon and use that.

This also removes the `aria-label` set on the icon as the title should
suffice.