### PR TITLE
[RFC] Add AbortSignal to the Hyperclick / Definition APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
     atom: false,
     document: false,
     window: false,
+    DOMException: false,
   },
 
   rules: {

--- a/flow-libs/need-to-upstream-to-flow-lib.js.flow
+++ b/flow-libs/need-to-upstream-to-flow-lib.js.flow
@@ -126,3 +126,9 @@ declare module 'module' {
 declare module 'console' {
   declare module.exports: any;
 }
+
+declare class DOMException {
+  constructor(message?: string, name?: string): void,
+  message: string,
+  name: string,
+}

--- a/modules/atom-ide-ui/pkg/atom-ide-definitions/lib/types.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-definitions/lib/types.js
@@ -10,6 +10,7 @@
  * @format
  */
 
+import type {AbortSignal} from 'nuclide-commons/AbortController';
 import type {NuclideUri} from 'nuclide-commons/nuclideUri';
 
 export type Definition = {
@@ -47,6 +48,7 @@ export type DefinitionProvider = {
   getDefinition: (
     editor: TextEditor,
     position: atom$Point,
+    options?: {signal: AbortSignal},
   ) => Promise<?DefinitionQueryResult>,
 };
 

--- a/modules/atom-ide-ui/pkg/atom-ide-definitions/package.json
+++ b/modules/atom-ide-ui/pkg/atom-ide-definitions/package.json
@@ -20,7 +20,8 @@
     },
     "definitions": {
       "versions": {
-        "0.1.0": "consumeDefinitionProvider"
+        "0.1.0": "consumeDefinitionProvider",
+        "1.0.0": "consumeDefinitionProvider"
       }
     },
     "definition-preview": {
@@ -32,7 +33,7 @@
   "providedServices": {
     "hyperclick": {
       "versions": {
-        "0.1.0": "getHyperclickProvider"
+        "1.0.0": "getHyperclickProvider"
       }
     }
   }

--- a/modules/atom-ide-ui/pkg/hyperclick/lib/HyperclickForTextEditor.js
+++ b/modules/atom-ide-ui/pkg/hyperclick/lib/HyperclickForTextEditor.js
@@ -16,6 +16,7 @@ import type {HyperclickSuggestion} from './types';
 import type Hyperclick from './Hyperclick';
 
 import {Point} from 'atom';
+import {fromAbortablePromise} from 'nuclide-commons/observable';
 import featureConfig from 'nuclide-commons-atom/feature-config';
 import {wordAtPosition} from 'nuclide-commons-atom/range';
 import {isPositionInRange} from 'nuclide-commons/range';
@@ -301,8 +302,10 @@ export default class HyperclickForTextEditor {
         return Observable.using(
           () => this._showLoading(),
           () =>
-            Observable.defer(() =>
-              this._hyperclick.getSuggestion(this._textEditor, position),
+            fromAbortablePromise(signal =>
+              this._hyperclick.getSuggestion(this._textEditor, position, {
+                signal,
+              }),
             )
               .startWith(null) // Clear the previous suggestion immediately.
               .catch(e => {

--- a/modules/atom-ide-ui/pkg/hyperclick/lib/types.js
+++ b/modules/atom-ide-ui/pkg/hyperclick/lib/types.js
@@ -10,6 +10,8 @@
  * @format
  */
 
+import type {AbortSignal} from 'nuclide-commons/AbortController';
+
 export type HyperclickProvider = {
   // Use this to provide a suggestion for single-word matches.
   // Optionally set `wordRegExp` to adjust word-matching.
@@ -17,6 +19,7 @@ export type HyperclickProvider = {
     textEditor: atom$TextEditor,
     text: string,
     range: atom$Range,
+    options?: {signal: AbortSignal},
   ) => Promise<?HyperclickSuggestion>,
 
   wordRegExp?: RegExp,
@@ -26,6 +29,7 @@ export type HyperclickProvider = {
   getSuggestion?: (
     textEditor: atom$TextEditor,
     position: atom$Point,
+    options?: {signal: AbortSignal},
   ) => Promise<?HyperclickSuggestion>,
 
   // Must be unique. Used for analytics.

--- a/modules/atom-ide-ui/pkg/hyperclick/package.json
+++ b/modules/atom-ide-ui/pkg/hyperclick/package.json
@@ -216,7 +216,8 @@
     },
     "hyperclick": {
       "versions": {
-        "0.1.0": "addProvider"
+        "0.1.0": "addProvider",
+        "1.0.0": "addProvider"
       }
     }
   },


### PR DESCRIPTION
The AbortController/AbortSignal spec is becoming the standard for DOM APIs (only fetch right now - looks like service workers are next: https://developers.google.com/web/updates/2017/09/abortable-fetch#the_future)

This adds an additional `options` argument to the Hyperclick and Definition APIs that contains an `AbortSignal` in `signal`, as suggested in the spec: https://dom.spec.whatwg.org/#abortcontroller-api-integration

Inside the Hyperclick implementation, this means that definition requests can be cancelled as soon as the user releases "cmd" for example (or starts moving the mouse to another line).

cc @damieng @daviwil @ljw1004 