### PR TITLE
Rely on FeatureLoader for registering config schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ const featureLoader = new FeatureLoader({
 featureLoader.load();
 
 module.exports = {
-  config: featureLoader.getConfig(),
   activate() {
     disposables = new UniversalDisposable(
       require('nuclide-commons-ui'),


### PR DESCRIPTION
This method was removed by D7960150 so once we sync that, we'll need to merge this.