### PR TITLE
Disable text selection when dragging tooltip

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-datatip/styles/datatip.less
+++ b/modules/atom-ide-ui/pkg/atom-ide-datatip/styles/datatip.less
@@ -14,6 +14,7 @@
 
 .datatip-dragging {
   cursor: -webkit-grabbing;
+  user-select: none;
 }
 
 .datatip-pinned {


### PR DESCRIPTION
This css fix prevents code inside the pinned tooltip from getting highlighted when dragging it around. 

![kapture 2018-06-04 at 10 40 30](https://user-images.githubusercontent.com/4623726/40907858-5ba224c4-67e5-11e8-93b5-b7fd793dee2c.gif)
