### PR TITLE
Hyperclick: fix editor:newline event

### DIFF
--- a/modules/atom-ide-ui/pkg/hyperclick/lib/SuggestionListElement.js
+++ b/modules/atom-ide-ui/pkg/hyperclick/lib/SuggestionListElement.js
@@ -173,9 +173,12 @@ class SuggestionList extends React.Component<Props, State> {
     this._subscriptions.dispose();
   }
 
-  _confirm() {
+  _confirm(event) {
     this._items[this.state.selectedIndex].callback();
     this._close();
+    if (event) {
+      event.stopImmediatePropagation();
+    }
   }
 
   _close() {


### PR DESCRIPTION
Fixed a bug that causes a line break when confirmed by non-enter key.

[![https://gyazo.com/3f211a423910318180850bb98729bd6d](https://i.gyazo.com/3f211a423910318180850bb98729bd6d.gif)](https://gyazo.com/3f211a423910318180850bb98729bd6d)